### PR TITLE
Disable removing leading zeroes in svgo

### DIFF
--- a/Android_Res_Export.sketchplugin/Contents/Sketch/export/export_vector_drawable.cocoascript
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/export/export_vector_drawable.cocoascript
@@ -102,7 +102,8 @@ var onRun = function(context) {
 }
 
 function optimizeSVG(svgo, svgIn) {
-    runCommand("/bin/bash", ["-l", "-c", svgo + " -p 2 '" + svgIn + "'"]);
+    var config = {plugins: [{convertPathData: {leadingZero: false}}]};
+    runCommand("/bin/bash", ["-l", "-c", svgo + " --config='" + JSON.stringify(config) + "' -p 2 '" + svgIn + "'"]);
 }
 
 function svg2vector(s2v, svgFile, vectorFile) {


### PR DESCRIPTION
Removing leading zeroes in paths is unsupported on some devices (Android studio shows errors if they are removed), this tells svgo to stop removing them. 

See this issue: https://issuetracker.google.com/issues/37008268