### PR TITLE
support for sketch 72

### DIFF
--- a/Android_Res_Export.sketchplugin/Contents/Sketch/export/export_vector_drawable.cocoascript
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/export/export_vector_drawable.cocoascript
@@ -223,7 +223,7 @@ function versionCompare(version1, version2) {
 }
 
 function styleLayer(layer) {
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (BCSketchInfo.shared().metadata().appVersion >= 52) {
         if (
             layer.class() == "MSShapeGroup" ||
             layer.class() == "MSRectangleShape" ||

--- a/Android_Res_Export.sketchplugin/Contents/Sketch/lib/common.js
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/lib/common.js
@@ -177,7 +177,7 @@ function groupFromSelection(context) {
 function groupFromLayers(layers) {
     var group;
     var layerArray = MSLayerArray.arrayWithLayers(layers);
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (BCSketchInfo.shared().metadata().appVersion >= 52) {
         group = MSLayerGroup.groupWithLayers(layerArray);
     } else {
         group = MSLayerGroup.groupFromLayers(layerArray);
@@ -235,7 +235,7 @@ function addRectShape(parent, beforeLayer, posX, posY, width, height, color, nam
     var rectangle = MSRectangleShape.alloc().init();
     rectangle.setRect(CGRectMake(posX, posY, width, height));
     var shapeGroup;
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (BCSketchInfo.shared().metadata().appVersion >= 52) {
         shapeGroup = rectangle;
     } else {
         shapeGroup = MSShapeGroup.shapeWithPath(rectangle);
@@ -532,7 +532,7 @@ function ga(context, eventCategory, eventAction, eventLabel, eventValue) {
     // Tracking ID
     url += "&tid=" + trackingID;
     // Source
-    url += "&ds=sketch" + MSApplicationMetadata.metadata().appVersion;
+    url += "&ds=sketch" + BCSketchInfo.shared().metadata().appVersion;
     // Client ID
     url += "&cid=" + uuid;
     // User GEO location

--- a/Android_Res_Export.sketchplugin/Contents/Sketch/manifest.json
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/manifest.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/Ashung/Android_Res_Export",
     "appcast": "https://ashung.github.io/Android_Res_Export/appcast.xml",
     "icon": "plugin_icon.png",
-    "version": "3.8.7",
+    "version": "3.8.8-SNAPSHOT",
     "identifier": "com.ashung.hung.android_res_export",
     "compatibleVersion": "4",
     "bundleVersion": "1",

--- a/Android_Res_Export.sketchplugin/Contents/Sketch/new/new_app_icon.cocoascript
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/new/new_app_icon.cocoascript
@@ -33,7 +33,7 @@ function importFromResource_toPage_withMetadata(context, resource, pageName, met
     pageForIcon.setName(pageName);
     documentData.insertPage_atIndex(pageForIcon, 0);
     documentData.setCurrentPage(pageForIcon);
-    if (MSApplicationMetadata.metadata().appVersion < 54) {
+    if (BCSketchInfo.shared().metadata().appVersion < 54) {
         doc.pageTreeLayoutDidChange();
     }
 

--- a/Android_Res_Export.sketchplugin/Contents/Sketch/new/new_nine_patch_asset.cocoascript
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/new/new_nine_patch_asset.cocoascript
@@ -77,7 +77,7 @@ var onRun = function(context) {
             groupPatch.setName("patch");
         }
 
-        if (MSApplicationMetadata.metadata().appVersion >= 53) {
+        if (BCSketchInfo.shared().metadata().appVersion >= 53) {
             groupNinePatch.fixGeometryWithOptions(1);
         } else {
             groupNinePatch.resizeToFitChildrenWithOption(1);

--- a/Android_Res_Export.sketchplugin/Contents/Sketch/preview/view_shape_code.cocoascript
+++ b/Android_Res_Export.sketchplugin/Contents/Sketch/preview/view_shape_code.cocoascript
@@ -294,9 +294,9 @@ function getLayerInfo(context, layer) {
         if (layer.children().count() == 2 || layer.children().count() == 1) {
 
             var shapePath;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (BCSketchInfo.shared().metadata().appVersion >= 52) {
                 shapePath = layer;
-            } else if (MSApplicationMetadata.metadata().appVersion >= 49) {
+            } else if (BCSketchInfo.shared().metadata().appVersion >= 49) {
                 shapePath = layer.children().lastObject();
             } else {
                 shapePath = layer.children().firstObject();
@@ -310,7 +310,7 @@ function getLayerInfo(context, layer) {
 
                         // Radius
                         var points;
-                        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+                        if (BCSketchInfo.shared().metadata().appVersion >= 49) {
                             points = shapePath.points();
                         } else {
                             points = shapePath.path().points();


### PR DESCRIPTION
> The internal class MSApplicationMetadata has been refactored into a new class, BCSketchInfo.
> 
> If a plugin was relying on any of the internal methods in MSApplicationMetadata, its code will not work (and may even crash Sketch if it’s passing the returned value unchecked to other parts of its code). The methods that previously lived in MSApplicationMetadata have been replaced with methods in BCSketchInfo.shared(), and most of the metadata you may need is available directly as a dictionary in BCSketchInfo.shared().metadata().

from https://developer.sketch.com/plugins/updates/new-in-sketch-72
closes https://github.com/Ashung/Android_Res_Export/issues/27